### PR TITLE
ENH adding mode 'distant'

### DIFF
--- a/circhic/_base.py
+++ b/circhic/_base.py
@@ -6,7 +6,7 @@ from matplotlib import colors
 from matplotlib.gridspec import GridSpec
 from matplotlib import patches
 from matplotlib.container import BarContainer
-from .utils import generate_circular_map as _generate_circular_data
+from .utils import generate_circular_map
 from .utils import generate_borders
 
 
@@ -49,6 +49,7 @@ class CircHiCFigure:
                  inner_radius=0, outer_radius=1,
                  resolution=1,
                  cmap="viridis",
+                 mode="reflect",
                  vmin=None,
                  vmax=None,
                  alpha=1,
@@ -92,6 +93,20 @@ class CircHiCFigure:
         cmap : string, optional, default : "viridis"
             A Matplotlib colormap.
 
+        mode : {"reflect", "distant"}, optional, default: "reflect"
+
+            - if `"reflect"`, the contact count matrix will be plotted from
+              `inner_gdis` to 0, then 0 to `outer_gdis`.
+            - if `"distant"`, the contact count matrix will be plotted from
+              `inner_gdis` to `outer_gdis`: this option is useful to visualize
+              contact counts far away from the diagonal.
+
+        vmin, vmax : float, optional, default: None
+            `vmin` and `vmax` define the data range that the colormap covers.
+            By default, the colormap covers the complete value range of the
+            supplied data.
+
+
         ax : matplotlib.axes.Axes object, optional, default: None
             Matplotlib Axes object. By default, will create one. Note that
             outer_radius and inner_radius will be ignored if `ax` is provided.
@@ -100,6 +115,11 @@ class CircHiCFigure:
         -------
         (im, ax) type of artist and axes
         """
+
+        if mode not in ["reflect", "distant"]:
+            raise ValueError(
+                "mode %s is unknown. Possible values for mode are "
+                "'reflect', and 'distant'.")
         n = counts.shape[0]
         if resolution is None:
             resolution = self.lengths.sum() / n
@@ -147,10 +167,11 @@ class CircHiCFigure:
         cir_inner_radius = inner_radius / outer_radius
 
         # Generate circular hic map
-        circular_data = _generate_circular_data(
+        circular_data = generate_circular_map(
             counts, resolution=resolution,
             granularity=granularity,
             origin=self.origin, inner_radius=cir_inner_radius,
+            mode=mode,
             inner_gdis=inner_gdis,
             outer_gdis=outer_gdis)
         if vmin is None:

--- a/examples/technical_contact_map/plot_reflect_vs_distant_mode.py
+++ b/examples/technical_contact_map/plot_reflect_vs_distant_mode.py
@@ -1,0 +1,35 @@
+"""
+===========================
+Reflect versus distant mode
+===========================
+
+In this example, we showcase the difference between the reflect versus the
+distant mode.
+"""
+from iced.normalization import ICE_normalization
+
+from circhic import datasets
+from circhic._base import CircHiCFigure
+
+
+# Load the data, compute the cumulative raw counts.
+data = datasets.load_ecoli()
+counts = data["counts"]
+lengths = data["lengths"]
+
+# Normale the data using ICE, and keep the biases
+counts, bias = ICE_normalization(counts, output_bias=True)
+
+###############################################################################
+# The reflect mode (the default) will plot data corresponding to the upper and
+# lower triangular of the original contact count matrix
+circhicfig = CircHiCFigure(lengths)
+im, ax = circhicfig.plot_hic(counts, mode="reflect", inner_gdis=50,
+                             inner_radius=0.3)
+
+###############################################################################
+# The distant mode will plot the data between inner_gdis and outer_gdis, thus
+# ignoring the section close to the diagonal.
+circhicfig = CircHiCFigure(lengths)
+im, ax = circhicfig.plot_hic(counts, mode="distant", inner_gdis=50,
+                             inner_radius=0.3)


### PR DESCRIPTION
The HiC contact map can now be plotted with two different mode:

- mode 'reflect', the default, which reflects the data around the
  diagonal. THis corresponds to plotting both upper and lower triangle
  of the original contact count matrix.
- mode 'distant', which plots the data from inner_gdis to outer_gdis.

closes #18

Attention @ijunier : I had to change some option names in order for the API to make sense.